### PR TITLE
BUG: Add numpy headers and other settings to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,7 @@ setup(
     name='diptest',
     cmdclass={'build_ext': build_ext},
     ext_modules=[diptest],
+    packages=['diptest'],
+    package_data={'diptest': ['dip_crit.txt']},
+    include_dirs = [np.get_include()]
 )


### PR DESCRIPTION
gcc was failing because it wasn't able to find the location of the numpy
headers.

The module could not be imported because it was not declared as a
package in setup.py and it needed to have the diptest/dip_crit.txt file
as part of the package data for the module to work.
